### PR TITLE
Fixing broken psdk_authentication_params_file path

### DIFF
--- a/launch/psdk_wrapper.launch.py
+++ b/launch/psdk_wrapper.launch.py
@@ -63,7 +63,7 @@ def generate_launch_description() -> LaunchDescription:
                                     'config/psdk_params.yaml')
 
     psdk_authentication_params_file = os.path.join(package_folder,
-                                                   'config/psdk_authentication_params.yaml')
+                                                   'config/psdk_authentication.yaml')
 
     link_config_file = os.path.join(package_folder,
                                     'config/link_config.json')


### PR DESCRIPTION
This PR fixes the broken link of the psdk_authentication_params_file.
The given name for the autentification in the config folder is: `config/psdk_authentication.yaml`

The change in `launch/psdk_wrapper.launch.py` consists in changing `psdk_authentication_params_file = os.path.join(package_folder, 'config/psdk_authentication_params.yaml')` to `psdk_authentication_params_file = os.path.join(package_folder, 'config/psdk_authentication.yaml')`
