### PR TITLE
[as2_platform_dji_psdk] Declare the frames of the platform commands

### DIFF
--- a/config/control_modes.yaml
+++ b/config/control_modes.yaml
@@ -6,7 +6,7 @@
 #
 # unset             = 0 = 0b0000
 # hover             = 1 = 0b0001
-# acro              = 2 = 0b0010
+# body_rates        = 2 = 0b0010
 # attitude          = 3 = 0b0011
 # speed             = 4 = 0b0100
 # speed_in_a_plane  = 5 = 0b0101
@@ -34,14 +34,14 @@
 #   SPEED + YAW ANGLE + ENU
 #   SPEED + YAW SPEED + ENU
 #   ATTITUDE + YAW ANGLE + ENU
-#   ACRO + YAW SPEED + FLU
+#   BODY_RATES + YAW SPEED + FLU
 #
 #-----------------------------------------------------------------
 
 available_modes:
   - 0b00000000 # UNSET
   - 0b00010000 # HOVER
-  # - 0b00100100 # ACRO (p,q,r, Thrust)
+  # - 0b00100100 # BODY_RATES (p,q,r, Thrust)
   # - 0b00110001 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust) 
   # - 0b00110101 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust) 
   # - 0b01000000 # SPEED with yaw ANGLE in the LOCAL_FLU_FRAME

--- a/config/control_modes.yaml
+++ b/config/control_modes.yaml
@@ -1,6 +1,6 @@
 #----------------------------------------------------------------
 # A complete control mode is an 8 bits flag 
-# (4bits control mode + 2 yaw mode bits + 2 reference frame bits)
+# (4bits control mode + 2 yaw mode bits + 2 reserved bits)
 #
 # ------------- mode codification (4 bits) ----------------------
 #
@@ -18,23 +18,19 @@
 # angle             = 0 = 0b00
 # speed             = 1 = 0b01
 # 
-# frame codification
-# 
-# local_frame_flu   = 0 = 0b00
-# global_frame_enu  = 1 = 0b01
-# global_frame_lla  = 2 = 0b10
+# Bits [1:0] are reserved and ignored
 # 
 #-----------------------------------------------------------------
 
 #------------------- DJI control modes -----------------------
 #
 #   UNSET
-#   POSITION + YAW ANGLE + ENU
-#   POSITION + YAW SPEED + ENU
-#   SPEED + YAW ANGLE + ENU
-#   SPEED + YAW SPEED + ENU
-#   ATTITUDE + YAW ANGLE + ENU
-#   BODY_RATES + YAW SPEED + FLU
+#   POSITION + YAW ANGLE
+#   POSITION + YAW SPEED
+#   SPEED + YAW ANGLE
+#   SPEED + YAW SPEED
+#   ATTITUDE + YAW ANGLE
+#   BODY_RATES + YAW SPEED
 #
 #-----------------------------------------------------------------
 
@@ -42,17 +38,13 @@ available_modes:
   - 0b00000000 # UNSET
   - 0b00010000 # HOVER
   # - 0b00100100 # BODY_RATES (p,q,r, Thrust)
-  # - 0b00110001 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust) 
-  # - 0b00110101 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust) 
-  # - 0b01000000 # SPEED with yaw ANGLE in the LOCAL_FLU_FRAME
-  # - 0b01000001 # SPEED with yaw ANGLE in the GLOBAL_ENU_FRAME
-  # - 0b01000100 # SPEED with yaw SPEED in the LOCAL_FLU_FRAME
-  - 0b01000101 # SPEED with yaw SPEED in the GLOBAL_ENU_FRAME
-  # - 0b01010000 # SPEED_IN_A_PLANE with yaw ANGLE in the LOCAL_FLU_FRAME
-  # - 0b01010001 # SPEED_IN_A_PLANE with yaw ANGLE in the GLOBAL_ENU_FRAME
-  # - 0b01010100 # SPEED_IN_A_PLANE with yaw SPEED in the LOCAL_FLU_FRAME
-  # - 0b01010101 # SPEED_IN_A_PLANE with yaw SPEED in the GLOBAL_ENU_FRAME
-  # - 0b01100001 # POSITION with yaw ANGLE in the GLOBAL_ENU_FRAME
-  # - 0b01100101 # POSITION with yaw SPEED in the GLOBAL_ENU_FRAME
-  # - 0b01110001 # TRAJECTORY with yaw ANGLE in the GLOBAL_ENU_FRAME
-  # - 0b01110101 # TRAJECTORY with yaw SPEED in the GLOBAL_ENU_FRAME
+  # - 0b00110000 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust)
+  # - 0b00110100 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust)
+  # - 0b01000000 # SPEED with yaw ANGLE
+  - 0b01000100 # SPEED with yaw SPEED
+  # - 0b01010000 # SPEED_IN_A_PLANE with yaw ANGLE
+  # - 0b01010100 # SPEED_IN_A_PLANE with yaw SPEED
+  # - 0b01100000 # POSITION with yaw ANGLE
+  # - 0b01100100 # POSITION with yaw SPEED
+  # - 0b01110000 # TRAJECTORY with yaw ANGLE
+  # - 0b01110100 # TRAJECTORY with yaw SPEED

--- a/include/as2_platform_dji_psdk/as2_platform_dji_psdk.hpp
+++ b/include/as2_platform_dji_psdk/as2_platform_dji_psdk.hpp
@@ -136,7 +136,6 @@ private:
   geometry_msgs::msg::Vector3 current_angular_velocity_;
 
   // Gimbal
-  as2::tf::TfHandler tf_handler_;
   bool enable_gimbal_;
   psdk_interfaces::msg::GimbalRotation gimbal_command_msg_;
   rclcpp::Time last_gimbal_command_time_;

--- a/src/as2_platform_dji_psdk.cpp
+++ b/src/as2_platform_dji_psdk.cpp
@@ -39,8 +39,7 @@ namespace as2_platform_dji_psdk
 {
 
 DJIMatricePSDKPlatform::DJIMatricePSDKPlatform(const rclcpp::NodeOptions & options)
-: as2::AerialPlatform(options),
-  tf_handler_(this)
+: as2::AerialPlatform(options)
 {
   // Create publishers
   velocity_command_pub_ = this->create_publisher<sensor_msgs::msg::Joy>(
@@ -179,6 +178,11 @@ bool DJIMatricePSDKPlatform::ownSetOffboardControl(bool offboard)
 bool DJIMatricePSDKPlatform::ownSetPlatformControlMode(const as2_msgs::msg::ControlMode & msg)
 {
   RCLCPP_INFO(this->get_logger(), "Setting control mode to %d", msg.control_mode);
+
+  // The PSDK velocity setpoints are given in the local ENU frame
+  setCommandPoseFrameId(this->getOdomFrameId());
+  setCommandTwistFrameId(this->getOdomFrameId());
+
   bool success = false;
   auto request = std::make_shared<std_srvs::srv::Trigger::Request>();
   auto response = std::make_shared<std_srvs::srv::Trigger::Response>();
@@ -392,7 +396,7 @@ void DJIMatricePSDKPlatform::gimbalControlCallback(
   desired_earth_orientation = desired_base_link_orientation;
 
   const std::string & target_frame = this->getEarthFrameId();
-  if (!tf_handler_.tryConvert(desired_earth_orientation, target_frame)) {
+  if (!tf_handler_->tryConvert(desired_earth_orientation, target_frame)) {
     RCLCPP_ERROR(
       this->get_logger(), "Could not transform desired gimbal orientation to earth frame");
     return;


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | — |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Not flown, builds and tests only |

---

## Description of contribution in a few bullet points

* **The platform declares the frames of its commands.** It names, per control
  mode, the TF frame it wants each command in, and the base class converts them
  before handing them over. The reference frame of the control mode is gone, so
  the platform no longer reads it, and the modes that only differed by frame
  collapse into one.

* **`ACRO` is renamed to `BODY_RATES`.** It was named after a flight mode of one
  autopilot, while every other mode is named after the quantity it commands.

Depends on #16, which has to be merged first, and on aerostack2/aerostack2#990.
